### PR TITLE
Add config to gatsby-browser for hooks support

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,4 +4,9 @@
  * See: https://www.gatsbyjs.org/docs/browser-apis/
  */
 
+// Fix for hooks support
+import { setConfig } from 'react-hot-loader'
+
+setConfig({ pureSFC: true })
+
 // You can delete this file if you're not using it

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -6,11 +6,6 @@ import Tags from './tags'
 import 'tachyons'
 import globalcss from '../utils/global'
 
-// Fix for hooks
-import { setConfig } from 'react-hot-loader'
-
-setConfig({ pureSFC: true })
-
 const Layout = ({ children }) => (
   <StaticQuery
     query={graphql`


### PR DESCRIPTION
Hi 👋

I'm using this starter for my shippening project and made this small change to where the setConfig is used (this way the user doesn't have to use the layout component, or remember to add the setConfig call in a different file to keep hooks support). 